### PR TITLE
Use process.cwd() instead of process.env.PWD

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const { Elm } = require('./dist')
 
 const app = Elm.Main.init({
   flags: {
-    pwd: process.env.PWD,
+    pwd: process.cwd(),
     argv: process.argv,
     versionMessage: require('./package.json').version
   }


### PR DESCRIPTION
## Summary
Replaces `process.env.PWD` with `process.cwd()` when passing the `pwd` flag to the Elm app in `index.js`.

`PWD` is a shell convention, not a Node guarantee: it's absent on Windows and in non-shell contexts (some CI runners, cron). When unset, `flags.pwd` was `undefined` and Elm threw a runtime exception at init (`Trying to initialize with unexpected flags`) before the CLI could print anything useful. `PWD` can also be stale or symlink-logical, whereas `process.cwd()` always reflects the actual working directory.

Fixes #13

## Verification
- `npm run build` succeeds
- `./bin.js src/Main.elm` prints the expected digraph
- `env -u PWD ./bin.js src/Main.elm` also prints the digraph (previously crashed at Elm init)

🤖 Generated with [Claude Code](https://claude.com/claude-code)