### PR TITLE
Default missing fields on fs errors sent through readFileError port

### DIFF
--- a/elm-node.js
+++ b/elm-node.js
@@ -5,10 +5,10 @@ module.exports = app => {
     fs.readFile(fileName, (e, file) => {
       if (e) {
         app.ports.readFileError.send({
-          code: e.code,
-          syscall: e.syscall,
-          path: e.path,
-          message: e.message
+          code: e.code || '',
+          syscall: e.syscall || '',
+          path: e.path || '',
+          message: e.message || ''
         })
       } else {
         app.ports.readFileSuccess.send({


### PR DESCRIPTION
## Summary

The `NativeError` alias in `src/Native/File.elm` declares `code`, `syscall`, `path`, and `message` all as `String`, but Node error objects don't guarantee all of those fields exist (`syscall`/`path` are absent on some error types). If any field is `undefined`, sending it through the inbound `readFileError` port makes Elm throw an uncatchable runtime exception instead of taking the clean `exitWithError` path.

This defaults each field to an empty string in `elm-node.js` so the error path is robust regardless of which fields Node populates.

Fixes #14

## Verification

- `npm run build` succeeds
- `./bin.js src/DoesNotExist.elm` prints a readable ENOENT error and exits with code 1 (no Elm runtime exception)
- `./bin.js src/Main.elm` still prints the expected digraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)