### PR TITLE
Fix makeAbsolute for ./-prefixed paths and bare ..

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -273,11 +273,17 @@ getParent dir =
 makeAbsolute : String -> String -> String
 makeAbsolute pwd file =
     case String.split "/" file of
+        [ "" ] ->
+            pwd
+
         ".." :: tail ->
             makeAbsolute (getParent pwd) (String.join "/" tail)
 
+        [ "." ] ->
+            pwd
+
         "." :: tail ->
-            pwd ++ String.join "/" tail
+            pwd ++ "/" ++ String.join "/" tail
 
         "" :: _ ->
             file


### PR DESCRIPTION
## Summary

Fixes two bugs in `makeAbsolute` in `src/Main.elm`:

- **`./`-prefixed paths were mangled.** The `"." :: tail` branch concatenated `pwd` and the rest of the path without a separator, so running `elm-to-dot ./src/Main.elm` from `/home/me/project` produced `/home/me/projectsrc/Main.elm`. The elm.json walk-up then climbed to the filesystem root and exited with a confusing `No elm.json file found.` The branch now joins with `pwd ++ "/" ++ ...`.

- **Bare `..` resolved to the empty string.** `makeAbsolute pwd ".."` recursed as `makeAbsolute (getParent pwd) ""`, and `String.split "/" ""` is `[""]`, which matched the absolute-path branch (`"" :: _`) and returned `""` — later yielding nonsense paths like `/Foo.elm`. An exact `[ "" ]` match now returns `pwd`, so bare `..` correctly resolves to the parent directory.

Also matches a bare `"."` exactly so it resolves to `pwd` without a trailing slash.

## Verification

- `npm run build` succeeds.
- From the repo root, `./bin.js ./src/Main.elm` now prints the digraph instead of `No elm.json file found.`
- Plain (`src/Main.elm`) and parent-relative (`../src/Main.elm` from `src/`) forms still work.

Fixes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)