### PR TITLE
Fix deadEndsToString ordering and missing spaces

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -316,7 +316,7 @@ deadEndsToString deadEnds =
             in
             case deadEnd.problem of
                 Parser.Expecting str ->
-                    "Expecting " ++ str ++ "at " ++ position
+                    "Expecting " ++ str ++ " at " ++ position
 
                 Parser.ExpectingInt ->
                     "ExpectingInt at " ++ position
@@ -343,7 +343,7 @@ deadEndsToString deadEnds =
                     "ExpectingSymbol " ++ str ++ " at " ++ position
 
                 Parser.ExpectingKeyword str ->
-                    "ExpectingKeyword " ++ str ++ "at " ++ position
+                    "ExpectingKeyword " ++ str ++ " at " ++ position
 
                 Parser.ExpectingEnd ->
                     "ExpectingEnd at " ++ position
@@ -357,4 +357,4 @@ deadEndsToString deadEnds =
                 Parser.BadRepeat ->
                     "BadRepeat at " ++ position
     in
-    List.foldl (++) "" (List.map deadEndToString deadEnds)
+    String.concat (List.map deadEndToString deadEnds)


### PR DESCRIPTION
## Summary

Fixes two small issues in `deadEndsToString` in `src/Main.elm`:

1. **Reversed output order**: the final fold used `List.foldl (++) ""`, which prepends each string, so multiple dead ends printed in reverse order. Replaced with `String.concat`, which preserves order.
2. **Missing spaces**: the `Parser.Expecting` and `Parser.ExpectingKeyword` branches were missing a space before `"at"`, rendering like `Expecting fooat row:1 col:5`. Added the missing space in both branches.

Fixes #17

## Verification

- `npm run build` compiles successfully.
- `./bin.js src/Main.elm` still prints the expected digraph.
- The parse-error path is hard to exercise end-to-end since elm-syntax accepts most files, but the diff is a minimal, mechanical change to string construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)