### PR TITLE
Emit NodeStmt for nodes with no surviving edges

### DIFF
--- a/src/Graph.elm
+++ b/src/Graph.elm
@@ -31,19 +31,33 @@ toString =
 toDot : Graph -> DL.Dot
 toDot graph =
     let
+        survivingDeps : String -> List String
+        survivingDeps node =
+            Dict.get node graph
+                |> Maybe.withDefault []
+                |> List.filter (\dep -> Dict.member dep graph)
+
+        isEdgeTarget : String -> Bool
+        isEdgeTarget node =
+            Dict.keys graph
+                |> List.any (\other -> List.member node (survivingDeps other))
+
         edgeStmts =
             Dict.toList graph
                 |> List.map
-                    (\( node, deps ) ->
-                        let
-                            edges =
-                                deps
-                                    |> List.filter (\dep -> Dict.member dep graph)
-                                    |> List.map (toNodeId >> DL.EdgeNode)
-                        in
-                        List.map
-                            (\edge -> DL.EdgeStmtNode (toNodeId node) edge [] [])
-                            edges
+                    (\( node, _ ) ->
+                        case List.map (toNodeId >> DL.EdgeNode) (survivingDeps node) of
+                            [] ->
+                                if isEdgeTarget node then
+                                    []
+
+                                else
+                                    [ DL.NodeStmt (toNodeId node) [] ]
+
+                            edges ->
+                                List.map
+                                    (\edge -> DL.EdgeStmtNode (toNodeId node) edge [] [])
+                                    edges
                     )
                 |> List.concat
     in

--- a/tests/GraphTests.elm
+++ b/tests/GraphTests.elm
@@ -34,6 +34,25 @@ suite =
                         |> Graph.insert "Utils" []
                         |> Graph.toString
                         |> Expect.equal (digraph [ "Main -> Utils" ])
+            , test "renders a module with no surviving imports as a bare node" <|
+                \_ ->
+                    Graph.empty
+                        |> Graph.insert "Main" [ "Json.Decode" ]
+                        |> Graph.toString
+                        |> Expect.equal (digraph [ "Main" ])
+            , test "renders an isolated module alongside connected ones" <|
+                \_ ->
+                    Graph.empty
+                        |> Graph.insert "Main" [ "Utils" ]
+                        |> Graph.insert "Utils" []
+                        |> Graph.insert "Orphan" []
+                        |> Graph.toString
+                        |> Expect.equal
+                            (digraph
+                                [ "Main -> Utils"
+                                , "Orphan"
+                                ]
+                            )
             , test "quotes module names that aren't bare identifiers" <|
                 \_ ->
                     Graph.empty


### PR DESCRIPTION
## Summary

`Graph.toDot` only emitted edge statements, so a node whose dependency list produced no surviving edges (after filtering to graph members) was dropped from the DOT output entirely. Pointing the tool at an entry file with no local imports produced an empty digraph:

```shell
$ elm-to-dot src/Standalone.elm
digraph {
    rankdir=LR
}
```

This change makes `toDot` emit a plain `NodeStmt` for any node that appears in no edge at all — neither as a source (no surviving outgoing edges) nor as a target of another node's edges. Such nodes now show up in the graph:

```shell
$ elm-to-dot src/Standalone.elm
digraph {
    rankdir=LR
    Standalone
}
```

Nodes already present via edges are intentionally skipped, so existing output (e.g. `./bin.js src/Main.elm`) is unchanged.

## Testing

- `npm run build` succeeds
- Ran `./bin.js` on a temporary `src/Standalone.elm` with no local imports: the module now appears as a lone node
- Ran `./bin.js src/Main.elm`: output is identical to before the change

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)