### PR TITLE
Fail loudly on malformed source-directories in elm.json

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -227,9 +227,21 @@ type alias ElmJson =
 elmJsonDecoder : Decode.Decoder ElmJson
 elmJsonDecoder =
     let
+        -- A missing "source-directories" field defaults to [ "src" ]
+        -- (package-style elm.json has no such field), but a present field
+        -- must decode strictly so a malformed value fails loudly instead
+        -- of silently falling back to the default.
         decodeSourceDirectories =
-            Decode.maybe (Decode.at [ "source-directories" ] (Decode.list Decode.string))
-                |> Decode.andThen (\sourceDirs -> Decode.succeed (Maybe.withDefault [ "src" ] sourceDirs))
+            Decode.maybe (Decode.field "source-directories" Decode.value)
+                |> Decode.andThen
+                    (\maybeValue ->
+                        case maybeValue of
+                            Nothing ->
+                                Decode.succeed [ "src" ]
+
+                            Just _ ->
+                                Decode.field "source-directories" (Decode.list Decode.string)
+                    )
     in
     Decode.map3 ElmJson
         (Decode.at [ "type" ] Decode.string)


### PR DESCRIPTION
## Problem

`elmJsonDecoder` in `src/Main.elm` wrapped the entire `source-directories` lookup in `Decode.maybe`:

```elm
Decode.maybe (Decode.at [ "source-directories" ] (Decode.list Decode.string))
```

Because `maybe` wrapped the whole `at`, a present-but-wrong-type field (e.g. `"source-directories": "src"` as a string, or a list containing a number) silently fell back to `[ "src" ]` instead of reporting a decode error. The crawl then proceeded with the wrong source directories and typically ended in a confusing missing-file result rather than pointing at the actual problem in elm.json.

## Fix

Only the field's *presence* is now checked optimistically (`Decode.maybe (Decode.field "source-directories" Decode.value)`); when the field exists, it is decoded strictly as `Decode.list Decode.string`. So:

- **Missing field** (package-style elm.json): still defaults to `[ "src" ]`.
- **Present but malformed field**: now fails loudly with a proper JSON decode error.

Note that a plain `Decode.oneOf [ strictDecoder, Decode.succeed [ "src" ] ]` would also have swallowed malformed fields, hence the explicit missing/malformed distinction.

## Verification

- `npm run build` compiles successfully.
- `./bin.js src/Main.elm` still prints the expected digraph (elm.json with valid `source-directories`).
- A temp project with `"source-directories": "src"` (string) now exits with:
  ```
  Failed to decode JSON.
  .../elm.json
  Problem with the value at json['source-directories']:

      "src"

  Expecting a LIST
  ```
- A temp package-style project whose elm.json lacks the field entirely still works, defaulting to `src/`.

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)