### PR TITLE
Dedupe dependency fetches and edges during crawl

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -11,13 +11,13 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/parser": "1.1.0",
+            "elm-community/list-extra": "8.7.0",
             "stil4m/elm-syntax": "7.3.8"
         },
         "indirect": {
             "elm/html": "1.0.0",
             "elm/regex": "1.0.0",
             "elm/virtual-dom": "1.0.3",
-            "elm-community/list-extra": "8.7.0",
             "hecrj/html-parser": "2.4.0",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -8,6 +8,7 @@ import Elm.RawFile as RawFile
 import Elm.Syntax.Node as Node
 import Graph exposing (Graph)
 import Json.Decode as Decode
+import List.Extra
 import Native.File exposing (File, NativeError)
 import Native.Log
 import Parser
@@ -167,6 +168,7 @@ update options msg model =
                                         sourceDirs |> List.map (\dir -> moduleToFile dir mod)
                                     )
                                 |> List.concat
+                                |> List.filter (\f -> not (List.member f state.pending))
 
                         withExternal =
                             if options.includeExternal then
@@ -252,6 +254,7 @@ parseModules elm =
                 , dependencies =
                     RawFile.imports v
                         |> List.map (.moduleName >> Node.value >> String.join ".")
+                        |> List.Extra.unique
                 }
             )
 


### PR DESCRIPTION
## Summary

Fixes two related deduplication gaps in the crawl logic in `src/Main.elm`:

- **Shared dependencies were fetched once per importer.** `filesToFetch` was only filtered against the graph, not against `pending`, so when two crawled modules both imported a not-yet-crawled module, the file was added to `pending` and read once per importer. Completion detection survived this only by accident (`List.filter ((/=) file.name)` removed all copies at once, and the `Ready` state's `Sub.none` dropped the late duplicate response). `filesToFetch` is now also filtered against `state.pending`, so each file is fetched exactly once.

- **Repeated imports produced parallel edges.** `dependencies` from `parseModules` wasn't deduplicated, so importing the same module twice yielded duplicate entries, rendering as parallel edges in the DOT output and triggering a redundant fetch. The list is now deduplicated with `List.Extra.unique` in `parseModules`, fixing both symptoms at the source.

Also promotes `elm-community/list-extra` from an indirect to a direct dependency in `elm.json` (it was already in the dependency tree).

Fixes #18

## Verification

- `npm run build` succeeds.
- `./bin.js src/Main.elm` and `./bin.js --include-external src/Main.elm` both print sensible digraphs with no duplicate edges (the repo's own modules share imports, exercising the dedup path).
- Diffed against master's output: identical except for the expected new `Main -> "List.Extra"` edge from the added import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)